### PR TITLE
Pin watson-developer-cloud SDK to prevent breakage.

### DIFF
--- a/notebooks/crypto-analysis.ipynb
+++ b/notebooks/crypto-analysis.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install watson_developer_cloud"
+    "!pip install watson_developer_cloud==1.5"
    ]
   },
   {


### PR DESCRIPTION
The 2.0 version of Watson python SDK contains breaking changes.
Pin the version for now, and provide fixes in a later patch.